### PR TITLE
Custom resource metadata fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For running unit tests:
 
 1. git clone this repository and cd into it
 1. create a new virtualenv: `mkvirtualenv ckanext-cfpb-extrafields`
-1. install requirements: `pip install requirements-test.txt`
+1. install requirements: `pip install -r requirements-test.txt`
 
 ## Installation
 

--- a/ckanext/cfpb_extrafields/plugin.py
+++ b/ckanext/cfpb_extrafields/plugin.py
@@ -37,6 +37,9 @@ class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
             'storage_location': [tk.get_validator('ignore_missing'),
                                  tk.get_converter('convert_to_extras')],
         })
+        schema['resources'].update({
+                'resource_type' : [ tk.get_validator('ignore_missing'),]
+        })
         # pprint.pprint(schema)
         return schema
 
@@ -71,6 +74,9 @@ class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
                         tk.get_validator('ignore_missing')],
             'storage_location': [tk.get_converter('convert_from_extras'),
                                  tk.get_validator('ignore_missing')],
+        })
+        schema['resources'].update({
+                'resource_type' : [ tk.get_validator('ignore_missing'),]
         })
         return schema
 

--- a/ckanext/cfpb_extrafields/templates/package/snippets/resource_form.html
+++ b/ckanext/cfpb_extrafields/templates/package/snippets/resource_form.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+
+{% block metadata_fields %}
+
+{{ form.select('resource_type', label=_('Resource type'), id='field-resource-type', options=[{'value': 'Canonical'}, {'value': 'Extract'}, {'value': 'Documentation'}, {'value': 'Data Dictionary'}], selected=data.sensitivity_level, error=errors.sensitivity_level, classes=['control-medium']) }}
+
+{% endblock %}
+


### PR DESCRIPTION
Added the pick-one-list custom metadata field for resources that Stefan requested, based on the ckan docs
http://docs.ckan.org/en/latest/extensions/adding-custom-fields.html?#adding-custom-fields-to-resources
